### PR TITLE
Static build of tagpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,10 @@ jobs:
                   # A list of supported versions can be found here:
                   # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
                   boost_version: 1.80.0
-                  platform_version: 22.04
+                  platform_version: 22.04 # as per runs-on
             - name: Install dependencies
               run: |
+                  find ${{steps.install-boost.outputs.BOOST_ROOT}}
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install boost
-              uses: MarkusJx/install-boost@v1.0.1
+              uses: MarkusJx/install-boost@v2
               id: install-boost
               with:
                   # REQUIRED: Specify the required boost version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib -static" pip install -e .
+                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib -Wc,-static" pip install -e .
               env:
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,10 @@ jobs:
                   platform_version: 22.04 # as per runs-on
             - name: Install dependencies
               run: |
-                  find ${{steps.install-boost.outputs.BOOST_ROOT}}
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage" pip install -e .
+                  CPPFLAGS="-coverage ${{steps.install-boost.outputs.BOOST_ROOT}}/include" pip install -e .
               env:
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
                   CPPFLAGS="-coverage" pip install -e .
+              env:
+                  LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest
               run: pytest -vvv --cov=tagpy --cov-report=term-missing --cov-report=lcov --cov-fail-under=50
             - name: Python Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,9 @@ jobs:
     test:
         strategy:
             matrix:
-                include:
-                    - ubuntu-version: 20.04
-                      python-version: 3.8
-                    - ubuntu-version: 22.04
-                      python-version: '3.10'
+                python-version: ['3.7', '3.8', '3.9', '3.10']
 
-        runs-on: ubuntu-${{ matrix.ubuntu-version }}
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v3
@@ -25,11 +21,20 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
+            - name: Install boost
+              uses: MarkusJx/install-boost@v1.0.1
+              id: install-boost
+              with:
+                  # REQUIRED: Specify the required boost version
+                  # A list of supported versions can be found here:
+                  # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
+                  boost_version: 1.81.0
+                  platform_version: 22.04
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
-                  sudo apt-get install -y --no-install-recommends libtag1-dev libboost-python-dev lcov
+                  sudo apt-get install -y --no-install-recommends libtag1-dev lcov
                   CPPFLAGS="-coverage" pip install -e .
             - name: Test with pytest
               run: pytest -vvv --cov=tagpy --cov-report=term-missing --cov-report=lcov --cov-fail-under=50

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" pip install -e .
+                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib" pip install -e .
               env:
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install boost
-              uses: MarkusJx/install-boost@v2
+              uses: MarkusJx/install-boost@v2.4.1
               id: install-boost
               with:
                   # REQUIRED: Specify the required boost version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib -Wc,-static" pip install -e .
+                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" \
+                    TAGPY_STATIC=True \
+                    BOOST_STATIC_LIB="${{steps.install-boost.outputs.BOOST_ROOT}}/lib/libboost_python${PYTHON_VERSION/./}-mt-x64.a" \
+                    pip install -e .
               env:
+                  PYTHON_VERSION: ${{matrix.python-version}}
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest
               run: pytest -vvv --cov=tagpy --cov-report=term-missing --cov-report=lcov --cov-fail-under=50

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
                   # REQUIRED: Specify the required boost version
                   # A list of supported versions can be found here:
                   # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-                  boost_version: 1.81.0
+                  boost_version: 1.80.0
                   platform_version: 22.04
             - name: Install dependencies
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib" pip install -e .
+                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" LDFLAGS="-L${{steps.install-boost.outputs.BOOST_ROOT}}/lib -static" pip install -e .
               env:
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   sudo apt-get install -y --no-install-recommends libtag1-dev lcov
-                  CPPFLAGS="-coverage ${{steps.install-boost.outputs.BOOST_ROOT}}/include" pip install -e .
+                  CPPFLAGS="-coverage -I${{steps.install-boost.outputs.BOOST_ROOT}}/include" pip install -e .
               env:
                   LD_LIBRARY_PATH: ${{steps.install-boost.outputs.BOOST_ROOT}}/lib
             - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ def main():
         "boost_python%d" % sys.version_info[0],
         "boost_python%d%d" % sys.version_info[:2],
         "boost_python-py%d%d" % sys.version_info[:2],
+        "boost_python%d%d-mt-x64" % sys.version_info[:2],
     ]
 
     for boost_option in boost_options:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
     INCLUDE_DIRS = ""  # conf["TAGLIB_INC_DIR"] + conf["BOOST_INC_DIR"]
     LIBRARY_DIRS = ""  # conf["TAGLIB_LIB_DIR"] + conf["BOOST_LIB_DIR"]
 
-    tagpy_static = bool(os.environ.get("TAGPY_STATIC", "False"))
+    tagpy_static = os.environ.get("TAGPY_STATIC", "False") == "True"
 
     if tagpy_static:
         LIBRARIES = []


### PR DESCRIPTION
To support work towards https://github.com/palfrey/tagpy/issues/8 by using static builds so we can build system-independent wheels. 

However, this is currently stuck in the middle of "argh, static linking for boost" problems, plus the fun of making distutils maybe use a static Python dev library, and I'm currently filing this one under "people can just install taglib and boost locally".