### PR TITLE
Fix c++23

### DIFF
--- a/src/wrapper/id3.cpp
+++ b/src/wrapper/id3.cpp
@@ -295,7 +295,7 @@ void exposeID3()
   {
     typedef ID3v2::AttachedPictureFrame cl;
     class_<cl, bases<ID3v2::Frame>, boost::noncopyable>
-      ("id3v2_AttachedPictureFrame", init<optional<const ByteVector &> >())
+      ("id3v2_AttachedPictureFrame", init<boost::python::optional<const ByteVector &> >())
       .DEF_SIMPLE_METHOD(textEncoding)
       .DEF_SIMPLE_METHOD(setTextEncoding)
       .DEF_SIMPLE_METHOD(mimeType)
@@ -312,7 +312,7 @@ void exposeID3()
   {
     typedef ID3v2::CommentsFrame cl;
     class_<cl, bases<ID3v2::Frame>, boost::noncopyable>
-      ("id3v2_CommentsFrame", init<optional<const ByteVector &> >())
+      ("id3v2_CommentsFrame", init<boost::python::optional<const ByteVector &> >())
       .def(init<String::Type>())
       .DEF_SIMPLE_METHOD(language)
       .DEF_SIMPLE_METHOD(setLanguage)
@@ -368,7 +368,7 @@ void exposeID3()
   {
     typedef ID3v2::TextIdentificationFrame cl;
     class_<cl, bases<ID3v2::Frame>, boost::noncopyable>
-      ("id3v2_TextIdentificationFrame", init<const ByteVector &, optional<String::Type> >())
+      ("id3v2_TextIdentificationFrame", init<const ByteVector &, boost::python::optional<String::Type> >())
       .def("setText", (void (cl::*)(const String &)) &cl::setText)
       .def("setText", (void (cl::*)(const StringList &)) &cl::setText)
       .DEF_SIMPLE_METHOD(textEncoding)
@@ -380,7 +380,7 @@ void exposeID3()
   {
     typedef ID3v2::UnsynchronizedLyricsFrame cl;
     class_<cl, bases<ID3v2::Frame>, boost::noncopyable>
-      ("id3v2_UnsynchronizedLyricsFrame", init<optional<const ByteVector &> >())
+      ("id3v2_UnsynchronizedLyricsFrame", init<boost::python::optional<const ByteVector &> >())
       .def(init<String::Type>())
       .DEF_SIMPLE_METHOD(language)
       .DEF_SIMPLE_METHOD(setLanguage)
@@ -395,7 +395,7 @@ void exposeID3()
     typedef ID3v2::UserTextIdentificationFrame cl;
     class_<cl, bases<ID3v2::TextIdentificationFrame>, boost::noncopyable>
       ("id3v2_UserTextIdentificationFrame", init<const ByteVector &>())
-      .def(init<optional<String::Type> >())
+      .def(init<boost::python::optional<String::Type> >())
       .DEF_SIMPLE_METHOD(description)
       .DEF_SIMPLE_METHOD(setDescription)
       .DEF_SIMPLE_METHOD(fieldList)
@@ -452,8 +452,8 @@ void exposeID3()
     typedef MPEG::File cl;
     class_<MPEG::File, bases<File>, boost::noncopyable>
       ("mpeg_File",
-       init<const char *, optional<bool, AudioProperties::ReadStyle> >())
-      .def(init<const char *, ID3v2::FrameFactory *, optional<bool, AudioProperties::ReadStyle> >())
+       init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
+      .def(init<const char *, ID3v2::FrameFactory *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       .def("save",
 	   #if (TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION < 12)
              (bool (MPEG::File::*)(int, bool, int))

--- a/src/wrapper/rest.cpp
+++ b/src/wrapper/rest.cpp
@@ -107,7 +107,7 @@ void exposeRest()
   {
     typedef Ogg::XiphComment cl;
     class_<cl, bases<Tag>, boost::noncopyable>
-      ("ogg_XiphComment", init<optional<const ByteVector &> >())
+      ("ogg_XiphComment", init<boost::python::optional<const ByteVector &> >())
       .DEF_SIMPLE_METHOD(fieldCount)
       .def("fieldListMap", &cl::fieldListMap,
            return_internal_reference<>())
@@ -137,14 +137,14 @@ void exposeRest()
   {
     typedef Ogg::FLAC::File cl;
     class_<cl, bases<Ogg::File>, boost::noncopyable>
-      ("ogg_flac_File", init<const char *, optional<bool, AudioProperties::ReadStyle> >())
+      ("ogg_flac_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       ;
   }
 
   {
     typedef Ogg::Vorbis::File cl;
     class_<cl, bases<Ogg::File>, boost::noncopyable>
-      ("ogg_vorbis_File", init<const char *, optional<bool, AudioProperties::ReadStyle> >())
+      ("ogg_vorbis_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       ;
   }
 
@@ -154,7 +154,7 @@ void exposeRest()
   {
     typedef APE::Footer cl;
     class_<cl, boost::noncopyable>(
-      "ape_Footer", init<optional<const ByteVector &> >())
+      "ape_Footer", init<boost::python::optional<const ByteVector &> >())
       .DEF_SIMPLE_METHOD(version)
       .DEF_SIMPLE_METHOD(headerPresent)
       .DEF_SIMPLE_METHOD(footerPresent)
@@ -221,8 +221,8 @@ void exposeRest()
   {
     typedef FLAC::File cl;
     class_<cl, boost::noncopyable, bases<File> >("flac_File",
-                                   init<const char *, optional<bool, AudioProperties::ReadStyle> >())
-      .def(init<const char *, ID3v2::FrameFactory *, optional<bool, AudioProperties::ReadStyle> >())
+                                   init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
+      .def(init<const char *, ID3v2::FrameFactory *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       .def("ID3v1Tag",
            (ID3v1::Tag *(FLAC::File::*)(bool))
            &FLAC::File::ID3v1Tag,
@@ -252,7 +252,7 @@ void exposeRest()
   {
     typedef MPC::File cl;
     class_<MPC::File, bases<File>, boost::noncopyable>
-      ("mpc_File", init<const char *, optional<bool, AudioProperties::ReadStyle> >())
+      ("mpc_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       .def("ID3v1Tag",
            (ID3v1::Tag *(cl::*)(bool))
            &cl::ID3v1Tag,
@@ -280,7 +280,7 @@ void exposeRest()
   {
     typedef TagLib::RIFF::WAV::File cl;
     class_<cl, bases<File>, boost::noncopyable>
-      ("wav_File", init<const char *, optional<bool, AudioProperties::ReadStyle> >())
+      ("wav_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       .def("ID3v2Tag",
            (ID3v2::Tag *(TagLib::RIFF::WAV::File::*)())
            &cl::ID3v2Tag,
@@ -306,7 +306,7 @@ void exposeRest()
   {
     typedef TagLib::MP4::File cl;
     class_<cl, bases<File>, boost::noncopyable>
-      ("mp4_File", init<const char *, optional<bool, AudioProperties::ReadStyle> >())
+      ("mp4_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       .def("tag",
            (MP4::Tag *(cl::*)() const)
            &cl::tag,


### PR DESCRIPTION
Fix build with c++23.
Replace optional with boost::python::optional

```
src/wrapper/id3.cpp:298:72: error: template argument 1 is invalid
  298 |       ("id3v2_AttachedPictureFrame", init<optional<const ByteVector &> >())

src/wrapper/rest.cpp:110:61: error: template argument 1 is invalid
  110 |       ("ogg_XiphComment", init<optional<const ByteVector &> >())
     
```