### PR TITLE
Add support for ogg containers with opus streams.

### DIFF
--- a/src/wrapper/rest.cpp
+++ b/src/wrapper/rest.cpp
@@ -36,6 +36,7 @@
 #include <taglib/mp4tag.h>
 #include <taglib/mp4coverart.h>
 #include <taglib/mp4item.h>
+#include <taglib/opusfile.h>
 
 #include "common.hpp"
 
@@ -154,6 +155,13 @@ void exposeRest()
     typedef Ogg::Vorbis::File cl;
     class_<cl, bases<Ogg::File>, boost::noncopyable>
       ("ogg_vorbis_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
+      ;
+  }
+
+  {
+    typedef Ogg::Opus::File cl;
+    class_<cl, bases<Ogg::File>, boost::noncopyable>
+      ("ogg_opus_File", init<const char *, boost::python::optional<bool, AudioProperties::ReadStyle> >())
       ;
   }
 

--- a/tagpy/__init__.py
+++ b/tagpy/__init__.py
@@ -73,6 +73,7 @@ class FileRef(object):
     def _getExtToModule():
         import tagpy.ogg.vorbis
         import tagpy.ogg.flac
+        import tagpy.ogg.opus
         import tagpy.mpeg
         import tagpy.mp4
         import tagpy.flac
@@ -90,6 +91,7 @@ class FileRef(object):
             "wav": tagpy.wav,
             "mp4": tagpy.mp4,
             "m4a": tagpy.mp4,
+            "opus": tagpy.ogg.opus,
             # ".wv": tagpy.wavpack,
             # ".spx": tagpy.ogg.speex,
             # ".tta": tagpy.trueaudio,

--- a/tagpy/ogg/opus.py
+++ b/tagpy/ogg/opus.py
@@ -1,0 +1,6 @@
+# Copyright 2025 Lubosz Sarnecki <lubosz@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import _tagpy
+
+File = _tagpy.ogg_opus_File


### PR DESCRIPTION
opus is the successor of vorbis and taglib supports it in the `opusfile.h` header.
`.opus` files are ogg containers with opus streams, this small patch adds support for them.
With this patch I am able to read metadata from opus files, even the covers seem to work.

Before this patch I was getting `ValueError: unable to find file type`  when I tried loading opus files.